### PR TITLE
Update regex to match flags with new format

### DIFF
--- a/main.py
+++ b/main.py
@@ -135,7 +135,7 @@ class NPSTBot(discord.Client):
                 await temp_msg.delete()
 
         # Match for CTF flags
-        if re.match(r"((N?PST)|(EGG)){[^}]{6,}}", msg.content, re.IGNORECASE):
+        if re.match(r"((N?PST)|(EGG)|(NSM)|(KRIPOS)){[^}]{6,}}", msg.content, re.IGNORECASE):
             await msg.delete()
             temp_msg = await msg.channel.send("Vennligst ikke send flagg!")
             await asyncio.sleep(5)

--- a/main.py
+++ b/main.py
@@ -135,7 +135,7 @@ class NPSTBot(discord.Client):
                 await temp_msg.delete()
 
         # Match for CTF flags
-        if re.match(r"(([Nn]?[Pp][Ss][Tt])|([Ee][Gg][Gg])){[^}]{6,}}", msg.content):
+        if re.match(r"((N?PST)|(EGG)){[^}]{6,}}", msg.content, re.IGNORECASE):
             await msg.delete()
             temp_msg = await msg.channel.send("Vennligst ikke send flagg!")
             await asyncio.sleep(5)


### PR DESCRIPTION
According to "Informasjon" on DASS, there are now two new flag formats: NSM and KRIPOS.
![bilde](https://github.com/jotjern/NPST-Bot/assets/40912933/19db6f86-6463-4d96-a7c6-cb2e94f9e482)

See the comparison from before and after this change:
| Before | After |
|-|-|
|![bilde](https://github.com/jotjern/NPST-Bot/assets/40912933/58b78714-f41f-4012-b287-6305e2f4dbfd)|![bilde](https://github.com/jotjern/NPST-Bot/assets/40912933/da0c7a2c-d5a6-4f3f-82e5-cc7b9f8d76c1)|